### PR TITLE
Correctly handle Unicode/UTF-8 terminal settings names.

### DIFF
--- a/terminal-control.rb
+++ b/terminal-control.rb
@@ -1,3 +1,4 @@
+Encoding.default_external = Encoding::UTF_8
 require 'rubygems' unless defined? Gem
 require './bundle/bundler/setup'
 require "alfredo"


### PR DESCRIPTION
Use UTF_8 encoding by default since we're dealing with OS X which defaults to UTF-8.
